### PR TITLE
fix: use rglob and parent.name for nested session directory structure

### DIFF
--- a/src/mcp_copilotcli_history/server.py
+++ b/src/mcp_copilotcli_history/server.py
@@ -52,7 +52,7 @@ def list_session_files(session_dir: Path | None = None) -> list[Path]:
         session_dir = get_session_state_dir()
     if not session_dir.exists():
         return []
-    files = list(session_dir.glob("*.jsonl"))
+    files = list(session_dir.rglob("*.jsonl"))
     return sorted(files, key=lambda f: f.stat().st_mtime, reverse=True)
 
 
@@ -62,7 +62,7 @@ _session_titles_cache: dict[str, str] = {}
 
 def get_session_title(file_path: Path, max_length: int = 80) -> str:
     """Extract the first user message as the session title."""
-    session_id = file_path.stem
+    session_id = file_path.parent.name
 
     if session_id in _session_titles_cache:
         return _session_titles_cache[session_id]
@@ -193,7 +193,7 @@ def search_sessions(
         if len(results) >= max_results:
             break
 
-        session_id = file_path.stem
+        session_id = file_path.parent.name
         session_title = get_session_title(file_path)
 
         try:
@@ -273,7 +273,7 @@ def list_recent_sessions(limit: int = 10) -> list[dict]:
     sessions = []
 
     for file_path in files:
-        session_id = file_path.stem
+        session_id = file_path.parent.name
         size_kb = file_path.stat().st_size / 1024
 
         start_time = "unknown"
@@ -412,11 +412,21 @@ def get_session_conversation(
         return [{"error": f"Session directory not found: {session_dir}"}]
 
     # Find the session file (supports partial ID matching)
-    files = list(session_dir.glob(f"{session_id}*.jsonl"))
-    if not files:
+    # Sessions are stored as <session_dir>/<session_id>/events.jsonl
+    matches = [
+        p
+        for p in session_dir.iterdir()
+        if p.is_dir() and p.name.startswith(session_id)
+    ]
+    if not matches:
         return [{"error": f"Session not found: {session_id}"}]
 
-    file_path = files[0]
+    # Use the first matching session directory's JSONL file
+    jsonl_files = list(matches[0].glob("*.jsonl"))
+    if not jsonl_files:
+        return [{"error": f"No JSONL file found in session: {matches[0].name}"}]
+
+    file_path = jsonl_files[0]
     messages = []
 
     try:
@@ -552,7 +562,7 @@ def search_tool_usage(
         if len(results) >= max_results:
             break
 
-        session_id = file_path.stem
+        session_id = file_path.parent.name
         session_title = get_session_title(file_path)
 
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,8 +32,10 @@ def temp_session_dir(tmp_path: Path):
     session_dir = tmp_path / "session-state"
     session_dir.mkdir()
 
-    # Create sample session file
-    session1 = session_dir / "abc123-session1.jsonl"
+    # Create sample session in subdirectory (real structure)
+    session1_dir = session_dir / "abc123-session1"
+    session1_dir.mkdir()
+    session1 = session1_dir / "events.jsonl"
     entries = [
         {
             "type": "session.start",
@@ -79,8 +81,10 @@ def temp_session_dir(tmp_path: Path):
         for entry in entries:
             f.write(json.dumps(entry) + "\n")
 
-    # Create another session file
-    session2 = session_dir / "def456-session2.jsonl"
+    # Create another session in subdirectory
+    session2_dir = session_dir / "def456-session2"
+    session2_dir.mkdir()
+    session2 = session2_dir / "events.jsonl"
     entries2 = [
         {
             "type": "session.start",
@@ -175,7 +179,7 @@ class TestGetSessionTitle:
 
     def test_extracts_first_user_message(self, temp_session_dir: Path):
         """Test extracting title from first user message."""
-        session_file = temp_session_dir / "abc123-session1.jsonl"
+        session_file = temp_session_dir / "abc123-session1" / "events.jsonl"
         title = get_session_title(session_file)
         assert title == "How do I create a Python function?"
 
@@ -183,7 +187,9 @@ class TestGetSessionTitle:
         """Test that long titles are truncated."""
         session_dir = tmp_path / "sessions"
         session_dir.mkdir()
-        session_file = session_dir / "long-title.jsonl"
+        session_subdir = session_dir / "long-title-session"
+        session_subdir.mkdir()
+        session_file = session_subdir / "events.jsonl"
 
         long_content = "A" * 200
         entry = {
@@ -200,12 +206,12 @@ class TestGetSessionTitle:
 
     def test_caches_results(self, temp_session_dir: Path):
         """Test that titles are cached."""
-        session_file = temp_session_dir / "abc123-session1.jsonl"
+        session_file = temp_session_dir / "abc123-session1" / "events.jsonl"
 
         # First call
         title1 = get_session_title(session_file)
 
-        # Check cache
+        # Check cache - key is parent directory name
         assert "abc123-session1" in _session_titles_cache
 
         # Second call should use cache


### PR DESCRIPTION

Fixes #1 - successfully tested locally (aka "works on my machine")

Sessions are stored as <session-dir>/<uuid>/events.jsonl but the code was using glob('*.jsonl') which only searches the root level, and file_path.stem which returns 'events' instead of the session UUID.

Changes:
- list_session_files: glob -> rglob to find JSONL files in subdirectories
- get_session_title: file_path.stem -> file_path.parent.name for session ID
- search_sessions, list_recent_sessions, search_tool_usage: same stem fix
- get_session_conversation: search subdirectories by session ID prefix
- Updated test fixture to use real directory structure (uuid/events.jsonl)