### PR TITLE
fix: convert timestamps from UTC to local timezone

### DIFF
--- a/src/mcp_copilotcli_history/server.py
+++ b/src/mcp_copilotcli_history/server.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -100,9 +100,10 @@ def get_session_title(file_path: Path, max_length: int = 80) -> str:
 
 
 def format_timestamp(ts: str) -> str:
-    """Format ISO timestamp for display."""
+    """Format ISO timestamp for display in local timezone."""
     try:
         dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        dt = dt.astimezone()  # Convert to system local timezone
         return dt.strftime("%Y-%m-%d %H:%M")
     except (ValueError, AttributeError):
         return ts[:16] if ts else "unknown"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -217,9 +217,14 @@ class TestFormatTimestamp:
     """Tests for format_timestamp function."""
 
     def test_format_iso_timestamp(self):
-        """Test formatting ISO timestamp."""
+        """Test formatting ISO timestamp converts to local timezone."""
+        from datetime import datetime, timezone
+
         result = format_timestamp("2025-12-01T10:30:45Z")
-        assert result == "2025-12-01 10:30"
+        # Compute expected local time from UTC
+        utc_dt = datetime(2025, 12, 1, 10, 30, 45, tzinfo=timezone.utc)
+        expected = utc_dt.astimezone().strftime("%Y-%m-%d %H:%M")
+        assert result == expected
 
     def test_format_invalid_timestamp(self):
         """Test handling invalid timestamp."""


### PR DESCRIPTION
### Summary

Fixes #3 — timestamps were displayed in UTC instead of the user's local system timezone.

### Changes

- **`server.py`**: Added `dt.astimezone()` call in `format_timestamp()` to convert UTC timestamps to the local system timezone before formatting
- **`test_server.py`**: Updated `test_format_iso_timestamp` to dynamically compute the expected local time instead of hardcoding a UTC value

### Before / After

| | Example (US Eastern) |
|---|---|
| **Before** | `2026-02-08 02:56` (UTC — looks like 2:56 AM) |
| **After** | `2026-02-07 21:56` (Local — correctly shows 9:56 PM ET) |