### PR TITLE
feat: add find_empty_sessions and delete_sessions tools for session cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ An MCP server that provides tools for searching through GitHub Copilot's convers
 - **View Conversations**: Read the full conversation from any session
 - **Search by File**: Find sessions that referenced specific files
 - **Search Tool Usage**: Find examples of how tools were used
+- **Find Empty Sessions**: Identify empty, abandoned, or trivially short sessions for cleanup
+- **Delete Sessions**: Safely remove low-value session directories (dry-run by default)
 
 ## Installation
 
@@ -164,6 +166,22 @@ Find sessions where specific tools were used.
 - `tool_name` (optional): Tool name to filter by
 - `max_results` (optional): Maximum results (default: 20)
 
+### find_empty_sessions
+
+Scan all session history and identify sessions that are empty, abandoned, or trivially short.
+
+**Arguments:**
+- `include_trivial` (optional): Include trivially short sessions (default: true)
+- `max_content_length` (optional): Character threshold for "trivial" classification (default: 200)
+
+### delete_sessions
+
+Delete session directories from Copilot history. Performs a dry run by default — set `confirm` to true to actually delete.
+
+**Arguments:**
+- `session_ids` (required): List of session IDs to delete
+- `confirm` (optional): Set to true to actually delete; false for dry run (default: false)
+
 ## Example Use Cases
 
 Once configured, you can ask your AI assistant questions like:
@@ -173,6 +191,15 @@ Once configured, you can ask your AI assistant questions like:
 - "Find conversations where I worked on main.py"
 - "How did I use the create_file tool before?"
 - "Show me the conversation from session abc123"
+
+### Session Cleanup Workflow
+
+You can use the session cleanup tools to keep your history tidy:
+
+1. **Find low-value sessions**: Ask "Find any empty or abandoned sessions in my Copilot history"
+2. **Review the results**: The tool returns each session's category (`empty`, `abandoned`, or `trivial`), a reason, and the session title so you can decide what to keep
+3. **Delete what you don't need**: Ask "Delete sessions aaa111, bbb222, ccc333" — this does a dry run first showing what would be deleted and bytes freed
+4. **Confirm deletion**: Ask "Delete those sessions with confirm set to true" to actually remove them
 
 ## Debugging
 

--- a/src/mcp_copilotcli_history/server.py
+++ b/src/mcp_copilotcli_history/server.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -100,9 +100,10 @@ def get_session_title(file_path: Path, max_length: int = 80) -> str:
 
 
 def format_timestamp(ts: str) -> str:
-    """Format ISO timestamp for display."""
+    """Format ISO timestamp for display in local timezone."""
     try:
         dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        dt = dt.astimezone()  # Convert to system local timezone
         return dt.strftime("%Y-%m-%d %H:%M")
     except (ValueError, AttributeError):
         return ts[:16] if ts else "unknown"

--- a/src/mcp_copilotcli_history/server.py
+++ b/src/mcp_copilotcli_history/server.py
@@ -52,7 +52,7 @@ def list_session_files(session_dir: Path | None = None) -> list[Path]:
         session_dir = get_session_state_dir()
     if not session_dir.exists():
         return []
-    files = list(session_dir.glob("*.jsonl"))
+    files = list(session_dir.rglob("*.jsonl"))
     return sorted(files, key=lambda f: f.stat().st_mtime, reverse=True)
 
 
@@ -62,7 +62,7 @@ _session_titles_cache: dict[str, str] = {}
 
 def get_session_title(file_path: Path, max_length: int = 80) -> str:
     """Extract the first user message as the session title."""
-    session_id = file_path.stem
+    session_id = file_path.parent.name
 
     if session_id in _session_titles_cache:
         return _session_titles_cache[session_id]
@@ -193,7 +193,7 @@ def search_sessions(
         if len(results) >= max_results:
             break
 
-        session_id = file_path.stem
+        session_id = file_path.parent.name
         session_title = get_session_title(file_path)
 
         try:
@@ -273,7 +273,7 @@ def list_recent_sessions(limit: int = 10) -> list[dict]:
     sessions = []
 
     for file_path in files:
-        session_id = file_path.stem
+        session_id = file_path.parent.name
         size_kb = file_path.stat().st_size / 1024
 
         start_time = "unknown"
@@ -412,11 +412,21 @@ def get_session_conversation(
         return [{"error": f"Session directory not found: {session_dir}"}]
 
     # Find the session file (supports partial ID matching)
-    files = list(session_dir.glob(f"{session_id}*.jsonl"))
-    if not files:
+    # Sessions are stored as <session_dir>/<session_id>/events.jsonl
+    matches = [
+        p
+        for p in session_dir.iterdir()
+        if p.is_dir() and p.name.startswith(session_id)
+    ]
+    if not matches:
         return [{"error": f"Session not found: {session_id}"}]
 
-    file_path = files[0]
+    # Use the first matching session directory's JSONL file
+    jsonl_files = list(matches[0].glob("*.jsonl"))
+    if not jsonl_files:
+        return [{"error": f"No JSONL file found in session: {matches[0].name}"}]
+
+    file_path = jsonl_files[0]
     messages = []
 
     try:
@@ -552,7 +562,7 @@ def search_tool_usage(
         if len(results) >= max_results:
             break
 
-        session_id = file_path.stem
+        session_id = file_path.parent.name
         session_title = get_session_title(file_path)
 
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -223,9 +223,14 @@ class TestFormatTimestamp:
     """Tests for format_timestamp function."""
 
     def test_format_iso_timestamp(self):
-        """Test formatting ISO timestamp."""
+        """Test formatting ISO timestamp converts to local timezone."""
+        from datetime import datetime, timezone
+
         result = format_timestamp("2025-12-01T10:30:45Z")
-        assert result == "2025-12-01 10:30"
+        # Compute expected local time from UTC
+        utc_dt = datetime(2025, 12, 1, 10, 30, 45, tzinfo=timezone.utc)
+        expected = utc_dt.astimezone().strftime("%Y-%m-%d %H:%M")
+        assert result == expected
 
     def test_format_invalid_timestamp(self):
         """Test handling invalid timestamp."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,8 +32,10 @@ def temp_session_dir(tmp_path: Path):
     session_dir = tmp_path / "session-state"
     session_dir.mkdir()
 
-    # Create sample session file
-    session1 = session_dir / "abc123-session1.jsonl"
+    # Create sample session in subdirectory (real structure)
+    session1_dir = session_dir / "abc123-session1"
+    session1_dir.mkdir()
+    session1 = session1_dir / "events.jsonl"
     entries = [
         {
             "type": "session.start",
@@ -79,8 +81,10 @@ def temp_session_dir(tmp_path: Path):
         for entry in entries:
             f.write(json.dumps(entry) + "\n")
 
-    # Create another session file
-    session2 = session_dir / "def456-session2.jsonl"
+    # Create another session in subdirectory
+    session2_dir = session_dir / "def456-session2"
+    session2_dir.mkdir()
+    session2 = session2_dir / "events.jsonl"
     entries2 = [
         {
             "type": "session.start",
@@ -175,7 +179,7 @@ class TestGetSessionTitle:
 
     def test_extracts_first_user_message(self, temp_session_dir: Path):
         """Test extracting title from first user message."""
-        session_file = temp_session_dir / "abc123-session1.jsonl"
+        session_file = temp_session_dir / "abc123-session1" / "events.jsonl"
         title = get_session_title(session_file)
         assert title == "How do I create a Python function?"
 
@@ -183,7 +187,9 @@ class TestGetSessionTitle:
         """Test that long titles are truncated."""
         session_dir = tmp_path / "sessions"
         session_dir.mkdir()
-        session_file = session_dir / "long-title.jsonl"
+        session_subdir = session_dir / "long-title-session"
+        session_subdir.mkdir()
+        session_file = session_subdir / "events.jsonl"
 
         long_content = "A" * 200
         entry = {
@@ -200,12 +206,12 @@ class TestGetSessionTitle:
 
     def test_caches_results(self, temp_session_dir: Path):
         """Test that titles are cached."""
-        session_file = temp_session_dir / "abc123-session1.jsonl"
+        session_file = temp_session_dir / "abc123-session1" / "events.jsonl"
 
         # First call
         title1 = get_session_title(session_file)
 
-        # Check cache
+        # Check cache - key is parent directory name
         assert "abc123-session1" in _session_titles_cache
 
         # Second call should use cache


### PR DESCRIPTION
## Summary

Adds two new MCP tools for session history housekeeping:

1. **`find_empty_sessions`** — Scans all session history and classifies low-value sessions into categories:
   - **empty**: No user messages at all (just `session.start`/`session.info` events)
   - **abandoned**: User sent a message but no assistant response was generated
   - **trivial**: Very short interaction (≤1 user+assistant message, total content under configurable threshold)

2. **`delete_sessions`** — Safely deletes session directories with a dry-run mode by default. Requires explicit `confirm=True` to actually delete. Reports bytes freed.

3. **Bug fixes included** (from prerequisite commits):
   - Fix nested session directory discovery (`*.jsonl` → `rglob`)
   - Fix session ID extraction (`file_path.stem` → `file_path.parent.name`)
   - Fix UTC timestamps displayed instead of local timezone

## Parameters

### `find_empty_sessions`
- `include_trivial` (bool, default: `True`) — Include trivially short sessions
- `max_content_length` (int, default: `200`) — Character threshold for "trivial" classification

### `delete_sessions`
- `session_ids` (list[str]) — Session UUIDs to delete
- `confirm` (bool, default: `False`) — Dry run by default; set `True` to actually delete

## Testing

- Full test coverage for all three categories (empty, abandoned, trivial)
- Tests for parameter behavior (`include_trivial`, `max_content_length`)
- Tests for `delete_sessions` (dry run, confirmed delete, missing sessions)
- All existing tests updated and passing

Closes #5